### PR TITLE
Allow Easy Configuration for Powerups

### DIFF
--- a/entities/entities/nut_slow_zombie.lua
+++ b/entities/entities/nut_slow_zombie.lua
@@ -234,7 +234,11 @@ function ENT:OnKilled(damageInfo)
 	self:BecomeRagdoll(damageInfo)
 	local function createPowerup(pos)
 		local ent1 = ents.Create("drop_powerups") 
-		local rand = table.Random({"ammobuff", "dp"})
+		local powerups = {}
+		for k,_ in pairs(validPowerups) do
+			table.insert(powerups, k)
+		end
+		local rand = table.Random(powerups) or "dp"
 		ent1.Buff = rand
 		ent1:SetModel( validPowerups[rand][1] )
 		pos.z = pos.z - ent1:OBBMaxs().z


### PR DESCRIPTION
Updating this, the regular zombie, and the config.lua with my edits will enable easy access to configurations of powerups.
