### PR TITLE
Added a bunch of chat commands for Nazi Zombies, mostly for debugging!

### DIFF
--- a/nzombies3/gamemode/misc/sv_chatcommands.lua
+++ b/nzombies3/gamemode/misc/sv_chatcommands.lua
@@ -103,3 +103,99 @@ NewChatCommand("/soundcheck", function(ply, text)
 		nz.Notifications.Functions.PlaySound("nz/round/game_over_4.mp3", 21)
 	end
 end)
+
+//puts all players into creative mode regardless of rank.
+NewChatCommand("/createall", function(ply, text)
+	if ply:IsSuperAdmin() then
+		nz.Rounds.Functions.CreateAllMode()
+	end
+end)
+
+//Either readies up all players or drops them in the following round.
+NewChatCommand("/readyall", function(ply, text)
+	for k,v in pairs(player.GetAll()) do
+			nz.Rounds.Functions.DropIn(v)
+	end
+	PrintMessage( HUD_PRINTTALK, "All players will drop in next round!" )
+end)
+
+//Gives all super admins 100000 points.
+NewChatCommand("/givepoints", function(ply, text)
+if ply:IsSuperAdmin() then
+for k,v in pairs(player.GetAll()) do
+		if v:IsSuperAdmin() then
+			v:GivePoints(100000)
+
+		end
+		PrintMessage( HUD_PRINTTALK, "Superadmins have been given 100000 points." )
+	end
+end)
+
+//Forces the round to end by killing all enemies on the map and forcing a new round. Untested, use at your own risk
+NewChatCommand("/endround", function(ply, text)
+if ply:IsSuperAdmin() or ply:IsAdmin() then
+for k,v in pairs(nz.Config.ValidEnemies) do
+		for k2,enemy in pairs(ents.FindByClass(v)) do
+			if enemy:IsValid() then
+				local insta = DamageInfo()
+				insta:SetDamage(enemy:Health())
+				insta:SetAttacker(Entity(0))
+				insta:SetDamageType(DMG_DISSOLVE)
+				//Delay so it doesnt "die" twice
+				timer.Simple(0.1, function() if enemy:IsValid() then enemy:TakeDamageInfo( insta ) end 
+
+end)
+			end
+		end	
+	end
+nz.Rounds.Functions.PrepareRound()
+end)
+
+//gives super admins all perks (Will only work they you have a compatible weapon, otherwise is buggy) Does give quick revive despite it not being programmed at the time of writing, for future proofing.
+NewChatCommand("/allperks", function(ply, text)
+if ply:IsSuperAdmin() then
+	for k,v in pairs(player.GetAll()) do
+		if v:IsSuperAdmin() then
+		v:GivePerk("jugg")
+		v:GivePerk("dtap")
+		v:GivePerk("sleight")
+		v:GivePerk("pap")
+		v:GivePerk("revive")
+		end
+	end
+end)
+
+//Removes your perks
+NewChatCommand("/removeperks", function(ply, text)
+ply:RemovePerks()
+end)
+
+//Removes all players perks.
+NewChatCommand("/removeperksall", function(ply, text)
+if ply:IsSuperAdmin() or ply:IsAdmin() then
+for k,v in pairs(player.GetAll()) do
+		v:RemovePerks()
+	end
+end)
+
+//Respawns random box. Included for debug reasons
+NewChatCommand("/respawn", function(ply, text)
+	if ply:IsSuperAdmin() or ply:IsAdmin() then
+nz.RandomBox.Functions.RemoveBox()
+nz.RandomBox.Functions.SpawnBox()
+	end
+end)
+
+//Respawns the user. Not tested, use with caution.
+NewChatCommand("/respawn", function(ply, text)
+if ply:IsSuperAdmin() or ply:IsAdmin() then
+nz.Rounds.Functions.ReSpawn(ply)
+	end
+end)
+
+//total reset of game
+NewChatCommand("/resetgame", function(ply, text)
+	if ply:IsSuperAdmin() then
+		nz.Rounds.Functions.ResetGame()
+	end
+end)

--- a/nzombies3/gamemode/round_handler/sv_handler.lua
+++ b/nzombies3/gamemode/round_handler/sv_handler.lua
@@ -180,6 +180,27 @@ function nz.Rounds.Functions.CreateMode()
 	nz.Rounds.Functions.SendSync()
 end
 
+function nz.Rounds.Functions.CreateAllMode()
+
+	if nz.Rounds.Data.CurrentState == ROUND_INIT then
+		PrintMessage( HUD_PRINTTALK, "The mode has been set to creative mode!" )
+		nz.Rounds.Data.CurrentState = ROUND_CREATE
+		//We are in create
+		for k,v in pairs(player.GetAll()) do
+				nz.Rounds.Functions.Create(v)
+		end
+		nz.Doors.Functions.LockAllDoors()
+	elseif nz.Rounds.Data.CurrentState == ROUND_CREATE then
+		PrintMessage( HUD_PRINTTALK, "The mode has been set to play mode!" )
+		nz.Rounds.Data.CurrentState = ROUND_INIT
+		//We are in play mode
+		for k,v in pairs(player.GetAll()) do
+			v:SetAsSpec()
+		end
+	end
+	nz.Rounds.Functions.SendSync()
+end
+
 function nz.Rounds.Functions.SetupGame()
 	
 	//Store a session of all our players


### PR DESCRIPTION
Most are for debugging purposes.

"/createall"
Sends all players into creative mode regardless of rank. Function is
identical to the regular nz.Rounds.Functions.CreateMode() function
except it spawns everybody.

"/dropinall"
Forces all players to drop in next round if they wouldn't otherwise.

"/givepoints"
Gives all Superadmins 100000 points for debugging purposes.

"/endround"
Forces the round to continue to the next. Could potentially be buggy,
didn't have a proper testing environment.

"/allperks"
Gives the Superadmins all perks. Includes Quick Revive despite not
having functionality at the time of writing, for futureproofing. Am
unsure of what happens if you don't have a compatible weapon with
SpeedCola/Dtap/PAP, assuming it just comes up with the normal error
message.

"/removeperks"
Removes your perks. Works for all players regardless of rank, as it only affects the user.

"/removeperksall"
Removes the perks from all players.

"/respawnbox"
Removes the box entity and then respawns it at any of it's spawn points
(presumably, was tested on a map with only one spawn point)

"/respawn"
Respawns the user. Works for admins and above

"/resetgame"
Total reset of game, just uses nz.Rounds.Functions.ResetGame() to do so.
Super admins only.